### PR TITLE
Huawei E3372 - host-less modem

### DIFF
--- a/docs/setup/gl-mt1300/internet.md
+++ b/docs/setup/gl-mt1300/internet.md
@@ -128,7 +128,7 @@ Here is a list of supported modems that we had tested before.
 | TP-Link MA260                          | 3G    | Yes    | GL.iNet         |           |
 | ZTE M823                               | 4G    | Yes    | Arnas Risqianto |           |
 | ZTE MF190                              | 3G    | Yes    | Arnas Risqianto |           |
-| Huawei E3372                           | 4G    | Yes    | anonymous       |           |
+| Huawei E3372                           | 4G    | Yes    | anonymous       | Host-less |
 | Pantech UML290VW (Verizon)             | 4G    | Yes    | GL.iNet/steven  | QMI       |
 | Pantech UML295 (Verizon)               | 4G    | Yes    | GL.iNet/steven  | Host-less |
 | Novatel USB551L (Verizon)              | 4G    | Yes    | GL.iNet/steven  | QMI       |


### PR DESCRIPTION
Hi,

we had some issues with setting up the Huawei E3372 modem, which is listed as normal modem in you documentation, but is actually host-less as in the [reference](http://ofmodemsandmen.com/modems.html) (NOTE: modem is mentioned twice, but only host-less worked for us).